### PR TITLE
Increased resources to 2cpu 4gb ram

### DIFF
--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -18,8 +18,8 @@ module api '../core/host/container-app.bicep' = {
     location: location
     containerAppsEnvironmentName: containerAppsEnvironmentName
     containerRegistryName: containerRegistryName
-    containerCpuCoreCount: '1.0'
-    containerMemory: '2.0Gi'
+    containerCpuCoreCount: '2.0'
+    containerMemory: '4.0Gi'
     env: [
       {
         name: 'AZURE_KEY_VAULT_ENDPOINT'

--- a/infra/core/host/container-app.bicep
+++ b/infra/core/host/container-app.bicep
@@ -12,10 +12,10 @@ param targetPort int = 80
 param serviceName string
 
 @description('CPU cores allocated to a single container instance, e.g. 0.5')
-param containerCpuCoreCount string = '0.5'
+param containerCpuCoreCount string = '2'
 
 @description('Memory allocated to a single container instance, e.g. 1Gi')
-param containerMemory string = '1.0Gi'
+param containerMemory string = '4.0Gi'
 
 var abbrs = loadJsonContent('../../abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))


### PR DESCRIPTION
Increased resources to 2cpu 4gb ram

@weikanglim - These setting work much quicker - else I can wait 1-2 minutes for apps to start. Java and spring need increased memory and processing due to the admin overhead they load