### PR TITLE
Change images to use Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+![Screenshot of deployed ToDo app](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -109,7 +109,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+![Application architecture diagram](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -217,7 +217,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+![Application architecture diagram with APIM](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 


### PR DESCRIPTION
The images in the readme.md use the HTML syntax (`<img src="..." width="..." alt="..."/>`) instead of Markdown syntax (`![...](...)`).

Because of this, the repository's images do not render in the Azure Samples browser. Here's how this repository renders in the browser:

<https://learn.microsoft.com/en-us/samples/azure-samples/todo-java-mongo-aca/todo-java-mongo-aca/>

![image](https://user-images.githubusercontent.com/5067401/227395924-1532bcb2-0fbe-4408-966c-aec4e2364c8d.png)

The simplest fix, I was told, is to update the images to use Markdown syntax for the images. Here's an example of a readme file that renders images correctly in the samples browser:

- Readme on GitHub: https://github.com/Azure-Samples/azure-cosmos-db-mongodb-xamarin-getting-started/blob/master/README.md?plain=1#L13-L15
- Page on Samples browser: https://learn.microsoft.com/en-us/samples/azure-samples/azure-cosmos-db-mongodb-xamarin-getting-started/azure-cosmos-db-mongodb-xamarin-getting-started/
  - ![image](https://user-images.githubusercontent.com/5067401/227396250-fd533072-8d13-4d6d-9102-0695f6c2acdc.png)

Unfortunately, you lose the width attributes when making that change.
