### PR TITLE
Update service name Azure DocumentDB in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ products:
 - ms-build-openjdk
 urlFragment: todo-java-mongo-aca
 name: Containerized React Web App with Java API and MongoDB on Azure
-description: A complete ToDo app on Azure Container Apps with Java API and Azure Cosmos API for MongoDB for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
+description: A complete ToDo app on Azure Container Apps with Java API and Azure DocumentDB (with MongoDB compatibility) for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
@@ -85,7 +85,7 @@ azd up
 This application utilizes the following Azure resources:
 
 - [**Azure Container Apps**](https://docs.microsoft.com/azure/container-apps/) to host the Web frontend and API backend
-- [**Azure Cosmos DB API for MongoDB**](https://docs.microsoft.com/azure/cosmos-db/mongodb/mongodb-introduction) for storage
+- [**Azure DocumentDB (with MongoDB compatibility)**](https://learn.microsoft.com/azure/documentdb/) for storage
 - [**Azure Monitor**](https://docs.microsoft.com/azure/azure-monitor/) for monitoring and logging
 - [**Azure Key Vault**](https://docs.microsoft.com/azure/key-vault/) for securing secrets
 


### PR DESCRIPTION
Updated the description to specify Azure DocumentDB instead of Azure Cosmos DB API for MongoDB.